### PR TITLE
Support for log entries created outside of the request/response cycle

### DIFF
--- a/airbrake/handlers.py
+++ b/airbrake/handlers.py
@@ -41,7 +41,7 @@ class AirbrakeHandler(logging.Handler):
             _, exn, trace = record.exc_info
 
         request = None
-        if record.request:
+        if hasattr(record, 'request'):
             request = record.request
 
         match = None


### PR DESCRIPTION
If a process is kicked off by a celery worker, the logging record will not have a request attribute.  I believe this check is safer.
