### PR TITLE
Fix to retrieve full backtrace.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ install:
   - pip install Django==$DJANGO_VERSION
   - pip install -e .
   - pip install coveralls mock
+  - pip install sh
 script: make coverage
 after_success: coveralls

--- a/airbrake/handlers.py
+++ b/airbrake/handlers.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from urllib2 import Request, urlopen, HTTPError
 import os
+import sys
 from xml.etree.ElementTree import Element, tostring, SubElement
 
 from django.core.urlresolvers import resolve


### PR DESCRIPTION
record.exc_info seems to be None in some cases, so using sys.exc_info instead.
